### PR TITLE
sometimes a file will come out with extra header nonsense above the f…

### DIFF
--- a/R/get_PITobs.R
+++ b/R/get_PITobs.R
@@ -174,6 +174,15 @@ get_PITobs = function(query_type = c('obs_site', 'release_site'),
     stop
   }
 
+  if(which(parsed[,1]=='tag_id')!=1){
+    # this will properly skip lines if needed.
+    parsed = httr::content(web_req,
+                           'text') %>%
+      read_delim(delim = ',',
+                 col_names = T,
+                 skip = which(parsed[,1]=='tag_id'))
+  }
+
   names(parsed) <- gsub(' ','_',tolower(names(parsed)))
 
   dat <- parsed[!is.na(parsed$tag_id),] # need to remove empty rows with metadata and bottom header row


### PR DESCRIPTION
…ield names. I experienced this with 2020 chinook obs_site query, where there are >100k records.  In this case, the funciton needs to re-assess how many rows to skip to properly parse the response. This should suffice.